### PR TITLE
feat(PRD-001): Add Plugin skeleton – composer.json, Plugin.php, DAL entity, migration, service stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .worktrees/
+firebase-debug.log

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+$finder = PhpCsFixer\Finder::create()
+    ->in([__DIR__ . '/src', __DIR__ . '/tests'])
+    ->name('*.php');
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@PSR12' => true,
+        'declare_strict_types' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'no_unused_imports' => true,
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
+        'single_quote' => true,
+        'trailing_comma_in_multiline' => true,
+    ])
+    ->setFinder($finder)
+    ->setRiskyAllowed(true);

--- a/README.md
+++ b/README.md
@@ -1,0 +1,270 @@
+# QuoteAgent for Shopware 6
+
+> KI-gestützte B2B-Angebotserstellung für Shopware 6 Rise Plan & Community Edition.
+
+**Zielgruppe:** KMU mit 5–50 Mitarbeitern, 5–50 Angebotsanfragen/Monat
+**Budget:** 49–79 €/Monat
+**GitHub:** https://github.com/Psheikomaniac/quote-agent
+
+---
+
+## Das Kernprinzip
+
+```
+Symfony berechnet (deterministisch)    KI formuliert (Text)
+───────────────────────────────        ──────────────────────
+Staffelpreise aus DAL             →    Professionellen Angebotstext
+Kundengruppen-Konditionen              Auf Basis fertiger Zahlen
+Mindestmarge-Prüfung                   In gewünschter Tonalität
+MwSt-Berechnung                        Auf Deutsch
+```
+
+**Die KI rechnet niemals selbst. Sie formuliert nur.**
+Alle numerischen Werte werden von PHP/Symfony berechnet und als fertiges JSON an die KI übergeben. Das garantiert korrekte, prüfbare Zahlen – unabhängig vom verwendeten KI-Modell.
+
+---
+
+## Features (V1.0)
+
+### Storefront
+- Angebotsformular eingebettet auf Produktseite, Kategorie-Listing und als Standalone-Route
+- Nur sichtbar für konfigurierte B2B-Kundengruppen (nicht für Gäste oder B2C)
+- Produktsuche mit Autocomplete (Artikelnummer, Produktname)
+- Kundenbereich „Meine Angebote" mit Statusübersicht und Direktlinks
+
+### Automatische Preiskalkulation
+- Staffelpreise aus Shopware DAL für die angefragte Menge
+- Kundengruppen-spezifische Netto/Brutto-Konditionen
+- Margenberechnung pro Position mit konfigurierbarer Mindestmarge (Warnung, kein Blocker)
+- Produkt ohne Einkaufspreis → Marge = `null`, keine Warnung
+
+### KI-Textgenerierung (BYOK)
+- Händler hinterlegt eigenen API-Key (Anthropic Claude oder OpenAI GPT-4o)
+- Konfigurierbarer Prompt: Tonalität (formal, freundlich, technisch) + eigene Anweisungen
+- Fallback bei API-Ausfall: Platzhalter-Text, kein Datenverlust
+- API-Kosten: ~0,09–0,15 €/Monat bei 30 Angeboten
+
+### PDF-Generierung
+- DomPDF-basiert, vollständig lokal (kein externer Dienst)
+- Händler-Logo, Positionen, MwSt-Zeile, Fußzeile (HRB, USt-ID, Bankverbindung)
+- Deutsche Zahlenformatierung (Komma als Dezimaltrenner)
+- PDF nur über authentifizierten Admin-Endpoint abrufbar (nicht öffentlich)
+
+### E-Mail-Versand
+- Zwei Modi: **Automatisch** (E-Mail sofort nach Kalkulation) oder **Manuelle Freigabe**
+- PDF als Anhang in der Kunden-E-Mail
+- Direktlinks „Angebot annehmen" / „Angebot ablehnen" ohne Login (tokenbasiert)
+- Shopware Mail-Template-System – im Admin editierbar
+
+### Admin-Backend (Vue.js)
+- Eigener Menüpunkt „B2B Angebote" in der Shopware Sidebar
+- Übersichtsliste mit Statusampel, Filter und Freitextsuche
+- Detailansicht: editierbarer KI-Text, PDF-Vorschau im Browser, Aktionsbuttons
+- API-Key Test-Button
+- Plugin-Einstellungen: Freigabemodus, Mindestmarge, Tonalität, E-Mail, Logo, Sichtbarkeit
+
+### Status-Tracking
+- Tokenbasierte Direktlinks für Kunden (kein Login nötig)
+- Stündlicher Cron-Job markiert abgelaufene Angebote automatisch
+- Händler-Benachrichtigung per E-Mail bei Annahme
+
+---
+
+## Status-Maschine
+
+```
+         ┌──────┐
+         │ new  │ ← Anfrage eingegangen, KI kalkuliert
+         └──┬───┘
+            │ Händler gibt frei / Auto-Send
+            ▼
+         ┌──────┐
+         │ sent │ ← Angebot beim Kunden
+         └──┬───┘
+  ┌─────────┼─────────┐
+  ▼         ▼         ▼ (Gültigkeitsdatum überschritten)
+┌──────────┐ ┌──────────┐ ┌─────────┐
+│ accepted │ │ rejected │ │ expired │
+└──────────┘ └──────────┘ └─────────┘
+```
+
+---
+
+## Technischer Stack
+
+| Schicht     | Technologie                              |
+|-------------|------------------------------------------|
+| Backend     | PHP 8.2+, Symfony 6.x (via Shopware)    |
+| ORM / DB    | Shopware DAL (kein direktes SQL!)        |
+| Admin-UI    | Vue.js 3 (Shopware Admin Component Lib) |
+| Storefront  | Twig + Vanilla JS                        |
+| PDF         | DomPDF ^2.0                              |
+| KI-Adapter  | Anthropic Claude API / OpenAI API (BYOK)|
+| Tests       | PHPUnit 10+ (Unit + Integration)         |
+| Linter      | PHP CS Fixer (PSR-12)                    |
+
+---
+
+## Verzeichnisstruktur
+
+```
+QuoteAgent/
+├── src/
+│   ├── Controller/
+│   │   └── QuoteRequestController.php
+│   ├── Core/
+│   │   ├── Quote/
+│   │   │   ├── QuoteRequestEntity.php
+│   │   │   ├── QuoteRequestDefinition.php
+│   │   │   └── QuoteRequestRepository.php
+│   │   ├── Pricing/
+│   │   │   └── QuotePricingService.php
+│   │   ├── AI/
+│   │   │   ├── QuoteTextGeneratorService.php
+│   │   │   ├── AiProviderInterface.php
+│   │   │   ├── AnthropicAdapter.php
+│   │   │   └── OpenAiAdapter.php
+│   │   └── Pdf/
+│   │       └── QuotePdfService.php
+│   ├── Subscriber/
+│   │   └── QuoteRequestSubscriber.php
+│   ├── ScheduledTask/
+│   │   └── QuoteExpirationTask.php
+│   ├── Administration/          (Vue-Komponenten)
+│   ├── Resources/
+│   │   ├── views/               (Twig Templates)
+│   │   ├── migration/
+│   │   │   └── Migration1709000000CreateQuoteRequestTable.php
+│   │   └── config/
+│   │       └── services.xml
+│   └── QuoteAgent.php
+├── tests/
+│   ├── Unit/
+│   └── Integration/
+├── docs/
+│   ├── README.md                (PRD-Übersicht)
+│   ├── PRD-001-plugin-foundation.md
+│   ├── PRD-002-storefront-form.md
+│   ├── PRD-003-pricing-service.md
+│   ├── PRD-004-ai-text-generation.md
+│   ├── PRD-005-pdf-generation.md
+│   ├── PRD-006-email-dispatch.md
+│   ├── PRD-007-admin-backend.md
+│   └── PRD-008-quote-status-tracking.md
+├── composer.json
+├── CLAUDE.md
+└── README.md
+```
+
+---
+
+## Datenbankschema (`b2b_quote_request`)
+
+| Spalte             | Typ         | Beschreibung                                       |
+|--------------------|-------------|----------------------------------------------------|
+| `id`               | BINARY(16)  | UUID, Primary Key                                  |
+| `quote_number`     | VARCHAR(64) | Menschenlesbare Nummer (`QA-YYYY-XXXX`)            |
+| `customer_id`      | BINARY(16)  | FK → `customer.id`                                 |
+| `status`           | VARCHAR(32) | `new`, `sent`, `accepted`, `rejected`, `expired`   |
+| `items`            | JSON        | Positionen: Produkt-ID, Menge, Preis, Marge        |
+| `customer_message` | LONGTEXT    | Freitext des Kunden                                |
+| `ai_text`          | LONGTEXT    | KI-generierter Angebotstext                        |
+| `total_amount`     | FLOAT       | Kalkulierter Gesamtbetrag (netto)                  |
+| `valid_until`      | DATETIME(3) | Gültigkeitsdatum                                   |
+| `accept_token`     | VARCHAR(64) | Einmal-Token für Direktlink „Angebot annehmen"     |
+| `pdf_path`         | VARCHAR(512)| Relativer Pfad zur generierten PDF-Datei           |
+| `created_at`       | DATETIME(3) | Shopware-Standard                                  |
+| `updated_at`       | DATETIME(3) | Shopware-Standard                                  |
+
+---
+
+## Lokale Entwicklung
+
+```bash
+# Plugin installieren und aktivieren (im Shopware-Root)
+bin/console plugin:install --activate QuoteAgent
+
+# Tests ausführen
+composer test
+
+# Code-Style prüfen (trocken)
+composer cs-fix --dry-run
+
+# Code-Style auto-fixen
+composer cs-fix
+```
+
+---
+
+## Implementierungs-Roadmap
+
+```
+Woche 1–2  │ PRD-001 │ Plugin-Skeleton, Entity, DB-Migration
+Woche 3    │ PRD-003 │ QuotePricingService (DAL, Staffelpreise, Marge)
+Woche 4    │ PRD-004 │ QuoteTextGeneratorService (Claude/GPT, BYOK)
+Woche 5    │ PRD-005 │ PDF-Generierung (DomPDF)
+           │ PRD-006 │ E-Mail-Versand (Shopware MailService)
+Woche 6    │ PRD-007 │ Admin-UI (Liste, Detail, Einstellungen)
+Woche 7    │ PRD-002 │ Storefront (Formular, Bestätigung, Kundenbereich)
+           │ PRD-008 │ Status-Tracking (Direktlinks, Cron-Job)
+Woche 8    │  –      │ Testing, Bugfixing, erster Testshop
+```
+
+Vollständige PRD-Details: [`docs/README.md`](docs/README.md)
+
+---
+
+## Preismodell
+
+| Plan         | Preis       | Limit                              |
+|--------------|-------------|------------------------------------|
+| Starter      | 49 €/Monat  | 30 Angebote/Monat                  |
+| Professional | 79 €/Monat  | Unbegrenzt + eigenes PDF-Branding  |
+
+---
+
+## Bewusst nicht in V1.0
+
+| Feature                    | Geplant für |
+|----------------------------|-------------|
+| RAG / Vektordatenbank      | V2.0        |
+| Lokale KI (Ollama/Llama)   | V2.0        |
+| Multi-Language Angebote    | V2.0        |
+| Analytics / Tracking       | V2.0        |
+| Flow Builder Integration   | V1.5        |
+| Automatische Bestellanlage | V3.0        |
+| ERP-Anbindung              | V3.0        |
+
+---
+
+## Abhängigkeiten
+
+```json
+{
+  "require": {
+    "php": ">=8.2",
+    "shopware/core": "~6.6.0",
+    "dompdf/dompdf": "^2.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^10.0",
+    "friendsofphp/php-cs-fixer": "^3.0"
+  }
+}
+```
+
+---
+
+## Sicherheits-Highlights
+
+- API-Keys nur in Shopware `SystemConfigService`, masked angezeigt (letzte 4 Zeichen)
+- `accept_token`: `bin2hex(random_bytes(32))` – 64 Zeichen kryptographisch sicher
+- DomPDF: `isRemoteEnabled = false` (kein externes HTTP aus PDF-Rendering)
+- PDF ausschließlich über authentifizierten Admin-Endpoint auslieferbar
+- CSRF-Schutz auf allen Storefront-Formularen
+
+---
+
+## Lizenz
+
+Proprietär – alle Rechte vorbehalten.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,42 @@
+{
+    "name": "psheikomaniac/quote-agent",
+    "description": "KI-gestützte B2B-Angebotserstellung für Shopware 6",
+    "type": "shopware-platform-plugin",
+    "license": "proprietary",
+    "version": "1.0.0",
+    "require": {
+        "php": ">=8.2",
+        "shopware/core": "~6.6.0",
+        "dompdf/dompdf": "^2.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.0",
+        "friendsofphp/php-cs-fixer": "^3.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "QuoteAgent\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "QuoteAgent\\Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": "phpunit",
+        "cs-fix": "php-cs-fixer fix src tests --config=.php-cs-fixer.php",
+        "cs-fix-dry": "php-cs-fixer fix src tests --config=.php-cs-fixer.php --dry-run --diff"
+    },
+    "extra": {
+        "shopware-plugin-class": "QuoteAgent\\QuoteAgent",
+        "label": {
+            "de-DE": "QuoteAgent – KI-gestützte B2B-Angebote",
+            "en-GB": "QuoteAgent – AI-powered B2B Quotes"
+        },
+        "description": {
+            "de-DE": "KI-gestützte B2B-Angebotserstellung für Shopware 6 (Rise/Community Edition)",
+            "en-GB": "AI-powered B2B quote creation for Shopware 6 (Rise/Community Edition)"
+        }
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         stopOnFailure="false">
+
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="integration">
+            <directory>tests/Integration</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </source>
+
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <ini name="display_errors" value="1"/>
+    </php>
+</phpunit>

--- a/src/Controller/QuoteRequestController.php
+++ b/src/Controller/QuoteRequestController.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace QuoteAgent\Controller;
+
+use Shopware\Storefront\Controller\StorefrontController;
+
+/**
+ * Handles storefront quote request form submissions and customer quote overview.
+ * Admin API endpoints are handled separately in the Admin Vue component layer.
+ *
+ * @see PRD-002 (Storefront) and PRD-007 (Admin) for full implementation
+ */
+class QuoteRequestController extends StorefrontController
+{
+    // Routes will be added in PRD-002 and PRD-007
+}

--- a/src/Core/AI/AiProviderInterface.php
+++ b/src/Core/AI/AiProviderInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace QuoteAgent\Core\AI;
+
+interface AiProviderInterface
+{
+    /**
+     * Generates text based on the given prompt.
+     * The prompt must contain pre-calculated numbers – the AI never computes values itself.
+     */
+    public function generateText(string $prompt): string;
+
+    /**
+     * Tests whether the provider is reachable with the configured API key.
+     */
+    public function testConnection(): bool;
+}

--- a/src/Core/AI/AnthropicAdapter.php
+++ b/src/Core/AI/AnthropicAdapter.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace QuoteAgent\Core\AI;
+
+use Psr\Log\LoggerInterface;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+
+/**
+ * Anthropic Claude API adapter (BYOK).
+ *
+ * @see PRD-004 for full implementation
+ */
+final class AnthropicAdapter implements AiProviderInterface
+{
+    public function __construct(
+        private readonly SystemConfigService $systemConfigService,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function generateText(string $prompt): string
+    {
+        // TODO: Implement in PRD-004
+        return '';
+    }
+
+    public function testConnection(): bool
+    {
+        // TODO: Implement in PRD-004
+        return false;
+    }
+}

--- a/src/Core/AI/OpenAiAdapter.php
+++ b/src/Core/AI/OpenAiAdapter.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace QuoteAgent\Core\AI;
+
+use Psr\Log\LoggerInterface;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+
+/**
+ * OpenAI GPT-4o adapter (BYOK).
+ *
+ * @see PRD-004 for full implementation
+ */
+final class OpenAiAdapter implements AiProviderInterface
+{
+    public function __construct(
+        private readonly SystemConfigService $systemConfigService,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function generateText(string $prompt): string
+    {
+        // TODO: Implement in PRD-004
+        return '';
+    }
+
+    public function testConnection(): bool
+    {
+        // TODO: Implement in PRD-004
+        return false;
+    }
+}

--- a/src/Core/AI/QuoteTextGeneratorService.php
+++ b/src/Core/AI/QuoteTextGeneratorService.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace QuoteAgent\Core\AI;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Orchestrates AI text generation for quotes.
+ * Receives pre-calculated pricing data from QuotePricingService and delegates
+ * text generation to the configured AI provider adapter.
+ *
+ * @see PRD-004 for full implementation
+ */
+final class QuoteTextGeneratorService
+{
+    public function __construct(
+        private readonly AiProviderInterface $aiProvider,
+        private readonly LoggerInterface $logger,
+    ) {}
+}

--- a/src/Core/Pdf/QuotePdfService.php
+++ b/src/Core/Pdf/QuotePdfService.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace QuoteAgent\Core\Pdf;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Generates PDF documents for quotes using DomPDF.
+ * DomPDF is always configured with isRemoteEnabled=false (no external HTTP).
+ * PDFs are only served via authenticated admin endpoint.
+ *
+ * @see PRD-005 for full implementation
+ */
+final class QuotePdfService
+{
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {}
+}

--- a/src/Core/Pricing/QuotePricingService.php
+++ b/src/Core/Pricing/QuotePricingService.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace QuoteAgent\Core\Pricing;
+
+use Psr\Log\LoggerInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+
+/**
+ * Calculates all pricing data for a quote request using Shopware DAL.
+ * Resolves tier prices, customer-group conditions, and checks minimum margins.
+ * The AI never receives raw product data – only the finished calculation result.
+ *
+ * @see PRD-003 for full implementation
+ */
+final class QuotePricingService
+{
+    public function __construct(
+        private readonly EntityRepository $productRepository,
+        private readonly SystemConfigService $systemConfigService,
+        private readonly LoggerInterface $logger,
+    ) {}
+}

--- a/src/Core/Quote/QuoteRequestCollection.php
+++ b/src/Core/Quote/QuoteRequestCollection.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace QuoteAgent\Core\Quote;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+
+/**
+ * @extends EntityCollection<QuoteRequestEntity>
+ */
+class QuoteRequestCollection extends EntityCollection
+{
+    protected function getExpectedClass(): string
+    {
+        return QuoteRequestEntity::class;
+    }
+}

--- a/src/Core/Quote/QuoteRequestDefinition.php
+++ b/src/Core/Quote/QuoteRequestDefinition.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace QuoteAgent\Core\Quote;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\DateTimeField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FloatField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+use Shopware\Core\Checkout\Customer\CustomerDefinition;
+
+final class QuoteRequestDefinition extends EntityDefinition
+{
+    public const ENTITY_NAME = 'b2b_quote_request';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    public function getEntityClass(): string
+    {
+        return QuoteRequestEntity::class;
+    }
+
+    public function getCollectionClass(): string
+    {
+        return QuoteRequestCollection::class;
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required()),
+            (new StringField('quote_number', 'quoteNumber'))->addFlags(new Required()),
+            (new FkField('customer_id', 'customerId', CustomerDefinition::class))->addFlags(new Required()),
+            (new StringField('status', 'status'))->addFlags(new Required()),
+            new JsonField('items', 'items'),
+            new LongTextField('customer_message', 'customerMessage'),
+            new LongTextField('ai_text', 'aiText'),
+            new FloatField('total_amount', 'totalAmount'),
+            new DateTimeField('valid_until', 'validUntil'),
+            (new StringField('accept_token', 'acceptToken'))->addFlags(new Required()),
+            new StringField('pdf_path', 'pdfPath'),
+            new ManyToOneAssociationField('customer', 'customer_id', CustomerDefinition::class),
+        ]);
+    }
+}

--- a/src/Core/Quote/QuoteRequestEntity.php
+++ b/src/Core/Quote/QuoteRequestEntity.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace QuoteAgent\Core\Quote;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+
+class QuoteRequestEntity extends Entity
+{
+    use EntityIdTrait;
+
+    protected string $quoteNumber = '';
+
+    protected string $customerId = '';
+
+    protected string $status = 'new';
+
+    protected ?array $items = null;
+
+    protected ?string $customerMessage = null;
+
+    protected ?string $aiText = null;
+
+    protected ?float $totalAmount = null;
+
+    protected ?\DateTimeInterface $validUntil = null;
+
+    protected string $acceptToken = '';
+
+    protected ?string $pdfPath = null;
+
+    protected ?CustomerEntity $customer = null;
+
+    public function getQuoteNumber(): string
+    {
+        return $this->quoteNumber;
+    }
+
+    public function setQuoteNumber(string $quoteNumber): void
+    {
+        $this->quoteNumber = $quoteNumber;
+    }
+
+    public function getCustomerId(): string
+    {
+        return $this->customerId;
+    }
+
+    public function setCustomerId(string $customerId): void
+    {
+        $this->customerId = $customerId;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): void
+    {
+        $this->status = $status;
+    }
+
+    public function getItems(): ?array
+    {
+        return $this->items;
+    }
+
+    public function setItems(?array $items): void
+    {
+        $this->items = $items;
+    }
+
+    public function getCustomerMessage(): ?string
+    {
+        return $this->customerMessage;
+    }
+
+    public function setCustomerMessage(?string $customerMessage): void
+    {
+        $this->customerMessage = $customerMessage;
+    }
+
+    public function getAiText(): ?string
+    {
+        return $this->aiText;
+    }
+
+    public function setAiText(?string $aiText): void
+    {
+        $this->aiText = $aiText;
+    }
+
+    public function getTotalAmount(): ?float
+    {
+        return $this->totalAmount;
+    }
+
+    public function setTotalAmount(?float $totalAmount): void
+    {
+        $this->totalAmount = $totalAmount;
+    }
+
+    public function getValidUntil(): ?\DateTimeInterface
+    {
+        return $this->validUntil;
+    }
+
+    public function setValidUntil(?\DateTimeInterface $validUntil): void
+    {
+        $this->validUntil = $validUntil;
+    }
+
+    public function getAcceptToken(): string
+    {
+        return $this->acceptToken;
+    }
+
+    public function setAcceptToken(string $acceptToken): void
+    {
+        $this->acceptToken = $acceptToken;
+    }
+
+    public function getPdfPath(): ?string
+    {
+        return $this->pdfPath;
+    }
+
+    public function setPdfPath(?string $pdfPath): void
+    {
+        $this->pdfPath = $pdfPath;
+    }
+
+    public function getCustomer(): ?CustomerEntity
+    {
+        return $this->customer;
+    }
+
+    public function setCustomer(?CustomerEntity $customer): void
+    {
+        $this->customer = $customer;
+    }
+}

--- a/src/Core/Quote/QuoteRequestRepository.php
+++ b/src/Core/Quote/QuoteRequestRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace QuoteAgent\Core\Quote;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+
+/**
+ * Typed wrapper around the auto-generated b2b_quote_request.repository service.
+ * Injecting this class instead of EntityRepository directly improves readability
+ * and enables precise mocking in unit tests.
+ */
+final class QuoteRequestRepository
+{
+    public function __construct(
+        private readonly EntityRepository $quoteRequestRepository,
+    ) {}
+
+    public function search(Criteria $criteria, Context $context): EntitySearchResult
+    {
+        return $this->quoteRequestRepository->search($criteria, $context);
+    }
+
+    public function create(array $data, Context $context): EntityWrittenContainerEvent
+    {
+        return $this->quoteRequestRepository->create($data, $context);
+    }
+
+    public function update(array $data, Context $context): EntityWrittenContainerEvent
+    {
+        return $this->quoteRequestRepository->update($data, $context);
+    }
+
+    public function delete(array $ids, Context $context): EntityWrittenContainerEvent
+    {
+        return $this->quoteRequestRepository->delete($ids, $context);
+    }
+}

--- a/src/Migration/Migration1709000000CreateQuoteRequestTable.php
+++ b/src/Migration/Migration1709000000CreateQuoteRequestTable.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace QuoteAgent\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+final class Migration1709000000CreateQuoteRequestTable extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1709000000;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement('
+            CREATE TABLE IF NOT EXISTS `b2b_quote_request` (
+                `id`               BINARY(16)    NOT NULL,
+                `quote_number`     VARCHAR(64)   NOT NULL,
+                `customer_id`      BINARY(16)    NOT NULL,
+                `status`           VARCHAR(32)   NOT NULL DEFAULT \'new\',
+                `items`            JSON,
+                `customer_message` LONGTEXT,
+                `ai_text`          LONGTEXT,
+                `total_amount`     DOUBLE,
+                `valid_until`      DATETIME(3),
+                `accept_token`     VARCHAR(64)   NOT NULL,
+                `pdf_path`         VARCHAR(512),
+                `created_at`       DATETIME(3)   NOT NULL,
+                `updated_at`       DATETIME(3),
+                PRIMARY KEY (`id`),
+                UNIQUE KEY `uniq.b2b_quote_request.quote_number` (`quote_number`),
+                UNIQUE KEY `uniq.b2b_quote_request.accept_token` (`accept_token`),
+                CONSTRAINT `fk.b2b_quote_request.customer_id`
+                    FOREIGN KEY (`customer_id`)
+                    REFERENCES `customer` (`id`)
+                    ON DELETE CASCADE
+                    ON UPDATE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        ');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // Drop logic is handled in QuoteAgent::uninstall() to prevent accidental
+        // data loss when operators run database:migrate-destructive for other plugins.
+    }
+}

--- a/src/QuoteAgent.php
+++ b/src/QuoteAgent.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace QuoteAgent;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Plugin\Context\ActivateContext;
+use Shopware\Core\Framework\Plugin\Context\DeactivateContext;
+use Shopware\Core\Framework\Plugin\Context\InstallContext;
+use Shopware\Core\Framework\Plugin\Context\UninstallContext;
+use Shopware\Core\Framework\Plugin\Context\UpdateContext;
+
+class QuoteAgent extends Plugin
+{
+    public function install(InstallContext $installContext): void
+    {
+        parent::install($installContext);
+    }
+
+    public function activate(ActivateContext $activateContext): void
+    {
+        parent::activate($activateContext);
+    }
+
+    public function deactivate(DeactivateContext $deactivateContext): void
+    {
+        parent::deactivate($deactivateContext);
+    }
+
+    public function uninstall(UninstallContext $uninstallContext): void
+    {
+        parent::uninstall($uninstallContext);
+
+        if ($uninstallContext->keepUserData()) {
+            return;
+        }
+
+        $connection = $this->container->get(Connection::class);
+        $connection->executeStatement('DROP TABLE IF EXISTS `b2b_quote_request`');
+    }
+
+    public function update(UpdateContext $updateContext): void
+    {
+        parent::update($updateContext);
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+               https://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <!-- ═══════════════════════════════════════════════
+             Entity Definition
+             Registering this tag auto-creates the
+             b2b_quote_request.repository service.
+        ════════════════════════════════════════════════ -->
+
+        <service id="QuoteAgent\Core\Quote\QuoteRequestDefinition">
+            <tag name="shopware.entity.definition" entity="b2b_quote_request"/>
+        </service>
+
+        <!-- ═══════════════════════════════════════════════
+             Repository Wrapper
+        ════════════════════════════════════════════════ -->
+
+        <service id="QuoteAgent\Core\Quote\QuoteRequestRepository">
+            <argument type="service" id="b2b_quote_request.repository"/>
+        </service>
+
+        <!-- ═══════════════════════════════════════════════
+             Pricing (PRD-003)
+        ════════════════════════════════════════════════ -->
+
+        <service id="QuoteAgent\Core\Pricing\QuotePricingService">
+            <argument type="service" id="product.repository"/>
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+            <argument type="service" id="logger"/>
+        </service>
+
+        <!-- ═══════════════════════════════════════════════
+             AI Adapters (PRD-004)
+        ════════════════════════════════════════════════ -->
+
+        <service id="QuoteAgent\Core\AI\AnthropicAdapter">
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+            <argument type="service" id="logger"/>
+        </service>
+
+        <service id="QuoteAgent\Core\AI\OpenAiAdapter">
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+            <argument type="service" id="logger"/>
+        </service>
+
+        <!-- ═══════════════════════════════════════════════
+             Text Generator (PRD-004)
+             Default adapter: Anthropic. Swap to OpenAiAdapter
+             by changing the argument below.
+        ════════════════════════════════════════════════ -->
+
+        <service id="QuoteAgent\Core\AI\QuoteTextGeneratorService">
+            <argument type="service" id="QuoteAgent\Core\AI\AnthropicAdapter"/>
+            <argument type="service" id="logger"/>
+        </service>
+
+        <!-- ═══════════════════════════════════════════════
+             PDF Service (PRD-005)
+        ════════════════════════════════════════════════ -->
+
+        <service id="QuoteAgent\Core\Pdf\QuotePdfService">
+            <argument type="service" id="logger"/>
+        </service>
+
+        <!-- ═══════════════════════════════════════════════
+             Controller (PRD-002, PRD-007)
+        ════════════════════════════════════════════════ -->
+
+        <service id="QuoteAgent\Controller\QuoteRequestController"
+                 public="true">
+            <tag name="controller.service_arguments"/>
+        </service>
+
+        <!-- ═══════════════════════════════════════════════
+             Event Subscriber (PRD-006, PRD-008)
+        ════════════════════════════════════════════════ -->
+
+        <service id="QuoteAgent\Subscriber\QuoteRequestSubscriber">
+            <argument type="service" id="logger"/>
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
+        <!-- ═══════════════════════════════════════════════
+             Scheduled Task (PRD-008)
+        ════════════════════════════════════════════════ -->
+
+        <service id="QuoteAgent\ScheduledTask\QuoteExpirationTask">
+            <tag name="shopware.scheduled.task"/>
+        </service>
+
+        <service id="QuoteAgent\ScheduledTask\QuoteExpirationTaskHandler">
+            <argument type="service" id="scheduled_task.repository"/>
+            <argument type="service" id="logger"/>
+            <argument type="service" id="QuoteAgent\Core\Quote\QuoteRequestRepository"/>
+            <tag name="messenger.message_handler"/>
+        </service>
+
+    </services>
+
+</container>

--- a/src/ScheduledTask/QuoteExpirationTask.php
+++ b/src/ScheduledTask/QuoteExpirationTask.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace QuoteAgent\ScheduledTask;
+
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTask;
+
+/**
+ * Scheduled task that runs hourly to mark overdue quotes as 'expired'.
+ *
+ * @see PRD-008 for full implementation
+ */
+final class QuoteExpirationTask extends ScheduledTask
+{
+    public static function getTaskName(): string
+    {
+        return 'quote_agent.quote_expiration';
+    }
+
+    public static function getDefaultInterval(): int
+    {
+        return 3600; // 1 hour
+    }
+}

--- a/src/ScheduledTask/QuoteExpirationTaskHandler.php
+++ b/src/ScheduledTask/QuoteExpirationTaskHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace QuoteAgent\ScheduledTask;
+
+use Psr\Log\LoggerInterface;
+use QuoteAgent\Core\Quote\QuoteRequestRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
+
+/**
+ * Handles the QuoteExpirationTask: transitions all 'sent' quotes past their
+ * valid_until date to status 'expired'.
+ *
+ * @see PRD-008 for full implementation
+ */
+final class QuoteExpirationTaskHandler extends ScheduledTaskHandler
+{
+    public function __construct(
+        EntityRepository $scheduledTaskRepository,
+        private readonly LoggerInterface $logger,
+        private readonly QuoteRequestRepository $quoteRequestRepository,
+    ) {
+        parent::__construct($scheduledTaskRepository);
+    }
+
+    public static function getHandledMessages(): iterable
+    {
+        return [QuoteExpirationTask::class];
+    }
+
+    public function run(): void
+    {
+        // TODO: Implement in PRD-008 – query b2b_quote_request WHERE status='sent'
+        // AND valid_until < NOW(), update to status='expired'
+    }
+}

--- a/src/Subscriber/QuoteRequestSubscriber.php
+++ b/src/Subscriber/QuoteRequestSubscriber.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace QuoteAgent\Subscriber;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Reacts to domain events in the quote lifecycle.
+ *
+ * @see PRD-006 (Email) and PRD-008 (Status Tracking) for full implementation
+ */
+final class QuoteRequestSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public static function getSubscribedEvents(): array
+    {
+        return [];
+    }
+}

--- a/tests/Unit/Core/Quote/QuoteRequestEntityTest.php
+++ b/tests/Unit/Core/Quote/QuoteRequestEntityTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace QuoteAgent\Tests\Unit\Core\Quote;
+
+use PHPUnit\Framework\TestCase;
+use QuoteAgent\Core\Quote\QuoteRequestEntity;
+
+final class QuoteRequestEntityTest extends TestCase
+{
+    public function testDefaultStatus(): void
+    {
+        $entity = new QuoteRequestEntity();
+
+        $this->assertSame('new', $entity->getStatus());
+    }
+
+    public function testOptionalFieldsAreNullByDefault(): void
+    {
+        $entity = new QuoteRequestEntity();
+
+        $this->assertNull($entity->getItems());
+        $this->assertNull($entity->getCustomerMessage());
+        $this->assertNull($entity->getAiText());
+        $this->assertNull($entity->getTotalAmount());
+        $this->assertNull($entity->getValidUntil());
+        $this->assertNull($entity->getPdfPath());
+        $this->assertNull($entity->getCustomer());
+    }
+
+    public function testGettersAndSetters(): void
+    {
+        $entity = new QuoteRequestEntity();
+
+        // TODO: Implement this test
+        // Set all fields using setters and verify via getters.
+        // Cover both non-null and null cases for optional fields.
+        // Hint: use \DateTime for validUntil, array for items.
+        $this->markTestIncomplete('Please implement testGettersAndSetters()');
+    }
+}

--- a/tests/Unit/QuoteAgentPluginTest.php
+++ b/tests/Unit/QuoteAgentPluginTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace QuoteAgent\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use QuoteAgent\QuoteAgent;
+use Shopware\Core\Framework\Plugin;
+
+final class QuoteAgentPluginTest extends TestCase
+{
+    public function testPluginClassExists(): void
+    {
+        $this->assertTrue(class_exists(QuoteAgent::class));
+    }
+
+    public function testPluginExtendsShopwarePlugin(): void
+    {
+        $reflection = new \ReflectionClass(QuoteAgent::class);
+
+        $this->assertTrue($reflection->isSubclassOf(Plugin::class));
+    }
+
+    public function testPluginIsFinal(): void
+    {
+        $reflection = new \ReflectionClass(QuoteAgent::class);
+
+        $this->assertTrue($reflection->isFinal());
+    }
+}


### PR DESCRIPTION
## Summary

Implements [Issue #1](https://github.com/Psheikomaniac/quote-agent/issues/1) – the complete Shopware 6 plugin foundation (PRD-001).

- **Plugin bootstrap**: `QuoteAgent.php` extending `Shopware\Core\Framework\Plugin` with proper `uninstall()` guard respecting `keepUserData`
- **DAL entity layer**: `QuoteRequestEntity`, `QuoteRequestDefinition`, `QuoteRequestCollection` and typed `QuoteRequestRepository` wrapper
- **Database migration**: `Migration1709000000CreateQuoteRequestTable` creates `b2b_quote_request` with `DOUBLE` for monetary fields, `UNIQUE` on `quote_number` and `accept_token`
- **Service stubs**: `QuotePricingService`, `QuoteTextGeneratorService`, `AnthropicAdapter`, `OpenAiAdapter`, `QuotePdfService`, `QuoteRequestController`, `QuoteRequestSubscriber`, `QuoteExpirationTask` + Handler – all registered in `services.xml`
- **`AiProviderInterface`**: 2-method contract (`generateText`, `testConnection`); both adapters implement it
- **Tooling**: `composer.json` with `composer test` and `composer cs-fix` scripts, `phpunit.xml`, `.php-cs-fixer.php` (PSR-12 + strict types)
- **Tests**: `QuoteAgentPluginTest` (reflection-based), `QuoteRequestEntityTest` (default values + open setter test for contributor)

## Why

Shopware 6 Rise/Community Edition has no native quote management below the €2,400/month Evolve plan. This skeleton is the P0 foundation all other PRDs build on – without it, no other feature can be developed.

## Test plan

- [ ] `composer install` succeeds
- [ ] `composer test` runs without errors (2 tests pass, 1 marked incomplete)
- [ ] `composer cs-fix --dry-run` exits clean
- [ ] `bin/console plugin:install QuoteAgent` runs without errors
- [ ] `bin/console plugin:activate QuoteAgent` executes migration, `b2b_quote_request` table exists
- [ ] `bin/console plugin:uninstall QuoteAgent` drops table (without `--keep-user-data`)
- [ ] All services resolvable in DI container

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)